### PR TITLE
Create base devenv Docker images

### DIFF
--- a/.github/workflows/publish-devenv-base-images.yml
+++ b/.github/workflows/publish-devenv-base-images.yml
@@ -1,0 +1,61 @@
+name: 'Publish Base Devenv Docker Images to GHCR'
+on:
+  push:
+    branches:
+      - 'main'
+      # for testing
+      - 'syncom/dockerfile-base-images'
+    paths:
+      - 'Dockerfile.idf_base'
+      - 'Dockerfile.zephyr_base'
+
+jobs:
+  publish-idf-container:
+    name: 'publish IDF devenv base container image'
+    runs-on: ubuntu-latest
+    env:
+      idf_source_image_tag: 'devenv_idf:base'
+      idf_target_image_name: 'devenv_idf_base'
+    steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@v3
+      - name: "Build base containers"
+        run: |
+          set -euxo pipefail
+          cd ${{ github.workspace }}
+          docker build -f Dockerfile.idf_base -t ${idf_source_image_tag} .
+      # Publish container image to GitHub Container Registry (GHCR)
+      - name: "Publish to ghcr.io"
+        run: |
+          set -euxo pipefail
+          cd ${{ github.workspace }}
+          GHCR_URI="ghcr.io"
+          GHCR_IDF_IMAGE_URI="${GHCR_URI}/${{ github.repository_owner }}/${idf_target_image_name}:${GITHUB_SHA}"
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login "${GHCR_URI}" -u ${{ github.actor }} --password-stdin
+          docker tag "${idf_source_image_tag}" "${GHCR_IDF_IMAGE_URI}"
+          docker push "${GHCR_IDF_IMAGE_URI}"
+
+  publish-zephyr-container:
+    name: 'publish Zephyr/MCUboot devenv base container image'
+    runs-on: ubuntu-latest
+    env:
+      zephyr_source_image_tag: 'devenv_zephyr:base'
+      zephyr_target_image_name: 'devenv_zephyr_base'
+    steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@v3
+      - name: "Build base containers"
+        run: |
+          set -euxo pipefail
+          cd ${{ github.workspace }}
+          docker build -f Dockerfile.zephyr_base -t ${zephyr_source_image_tag} .
+      # Publish container image to GitHub Container Registry (GHCR)
+      - name: "Publish to ghcr.io"
+        run: |
+          set -euxo pipefail
+          cd ${{ github.workspace }}
+          GHCR_URI="ghcr.io"
+          GHCR_ZEPHYR_IMAGE_URI="${GHCR_URI}/${{ github.repository_owner }}/${zephyr_target_image_name}:${GITHUB_SHA}"
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login "${GHCR_URI}" -u ${{ github.actor }} --password-stdin
+          docker tag "${zephyr_source_image_tag}" "${GHCR_ZEPHYR_IMAGE_URI}"
+          docker push "${GHCR_ZEPHYR_IMAGE_URI}"

--- a/.github/workflows/publish-devenv-base-images.yml
+++ b/.github/workflows/publish-devenv-base-images.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - 'main'
-      # for testing
-      - 'syncom/dockerfile-base-images'
     paths:
       - 'Dockerfile.idf_base'
       - 'Dockerfile.zephyr_base'

--- a/Dockerfile.idf_base
+++ b/Dockerfile.idf_base
@@ -1,0 +1,37 @@
+
+# To build Docker image, call `docker build` from the parent directory of this
+# file
+#
+# References:
+# - Secure boot: https://docs.mcuboot.com/readme-espressif.html
+# - ESP32 get started:
+# https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/get-started/linux-macos-setup.html
+FROM ubuntu:22.04@sha256:965fbcae990b0467ed5657caceaec165018ef44a4d2d46c7cdea80a9dff0d1ea
+
+# 20230121
+ENV ESPIDF_COMMIT_SHA="49551cc48cb3cdd5563059028749616de313f0ec"
+SHELL ["/bin/bash", "-c"]
+# Install dependencies
+RUN apt update && apt upgrade -y && \
+    apt install -y git wget flex bison gperf python3 python3-venv \
+    cmake ninja-build ccache libffi-dev libssl-dev dfu-util libusb-1.0-0 \
+    vim xxd file
+
+ENV HOME /home/esp
+WORKDIR ${HOME}/
+
+# Obtain ESP-IDF, and set up tools & environment
+RUN git clone https://github.com/espressif/esp-idf.git && \
+    cd esp-idf && \
+    git checkout ${ESPIDF_COMMIT_SHA} && \
+    git submodule update --init --recursive && \
+    ./install.sh esp32 esp32s2 esp32s3
+
+# Create user "esp". Group dialout is for USB access from container
+RUN useradd -g dialout -m esp && \
+    cp /root/.bashrc /home/esp/ && \
+    chown -R --from=root esp /home/esp
+
+USER esp
+
+CMD ["/bin/bash"]

--- a/Dockerfile.zephyr_base
+++ b/Dockerfile.zephyr_base
@@ -1,0 +1,86 @@
+# To build Docker image, call `docker build` from the parent directory of this
+# file
+#
+# Reference:
+# - Secure boot: https://docs.mcuboot.com/readme-espressif.html
+# - Zephyr dev: https://docs.zephyrproject.org/latest/develop/getting_started/index.html
+FROM ubuntu:22.04@sha256:965fbcae990b0467ed5657caceaec165018ef44a4d2d46c7cdea80a9dff0d1ea
+
+# 20230301
+ENV MCUBOOT_COMMIT_SHA="b56a65f5cb32898a20da101ca0e3d97f8c0a3d48"
+# 20230121
+ENV ESPIDF_COMMIT_SHA="49551cc48cb3cdd5563059028749616de313f0ec"
+# 20230307. This revision has https://github.com/zephyrproject-rtos/zephyr/pull/55291
+ENV ZEPHYR_MR_COMMIT_SHA="e26bf578c6746d3800f1d62c803bbee3cb12390d"
+
+ENV HOME /home/esp
+
+WORKDIR ${HOME}/
+SHELL ["/bin/bash", "-c"]
+# Install dependencies
+RUN apt update && apt upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y \
+      git wget flex bison gperf vim xxd xz-utils file \
+      python3-dev python3-venv python3-pip python3-setuptools python3-tk python3-wheel \
+      cmake ninja-build make gcc gcc-multilib g++-multilib \
+      ccache libffi-dev libssl-dev dfu-util device-tree-compiler libusb-1.0-0 \
+      libsdl2-dev libmagic1 udev libarchive-zip-perl vbindiff
+
+# Create user "esp". Group dialout is for USB access from container
+RUN useradd -g dialout -m esp && \
+    cp /root/.bashrc /home/esp/ && \
+    chown -R --from=root esp /home/esp
+
+USER esp
+
+#############################
+# MCUBoot development
+#############################
+
+RUN git clone https://github.com/mcu-tools/mcuboot.git && \
+    cd mcuboot && \
+    git checkout ${MCUBOOT_COMMIT_SHA} && \
+    pip3 install -r scripts/requirements.txt && \
+    git submodule update --init --recursive --checkout boot/espressif/hal/esp-idf && \
+    git submodule update --init --recursive ext/mbedtls && \
+    cd boot/espressif/hal/esp-idf && \
+    ./install.sh esp32 esp32s2 esp32s3
+
+#############################
+# Zephyr development
+#############################
+RUN cd ${HOME} && \
+    mkdir -p ${HOME}/zephyrproject && \
+    python3 -m venv ${HOME}/zephyrproject/.venv
+
+# Get Zephyr and install python deps
+RUN source ${HOME}/zephyrproject/.venv/bin/activate && \
+    pip install west && \
+    cd ${HOME}/zephyrproject && \
+    mkdir -p zephyr && \
+    cd zephyr && \
+    git init && \
+    git remote add origin https://github.com/zephyrproject-rtos/zephyr.git && \
+    git fetch --depth 1 origin ${ZEPHYR_MR_COMMIT_SHA} && \
+    git checkout FETCH_HEAD && \
+    cd .. && \
+    # Init with local manifest repo
+    west init -l ${HOME}/zephyrproject/zephyr && \
+    west update && \
+    west zephyr-export && \
+    pip install -r ${HOME}/zephyrproject/zephyr/scripts/requirements.txt && \
+    west blobs fetch hal_espressif && \
+    pip install kconfiglib && deactivate
+
+# Install Zephyr SDK
+RUN source ${HOME}/zephyrproject/.venv/bin/activate && \
+    wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/zephyr-sdk-0.16.1_linux-x86_64.tar.xz && \
+    wget -O - https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.1/sha256.sum | shasum --check --ignore-missing && \
+    mkdir zephyr-sdk && \
+    tar xf zephyr-sdk-0.16.1_linux-x86_64.tar.xz --strip=1 --directory zephyr-sdk && \
+    rm zephyr-sdk-0.16.1_linux-x86_64.tar.xz && \
+    cd zephyr-sdk && \
+    # Install esp32 toolchain and host tools; register cmake package
+    echo | ./setup.sh -t xtensa-espressif_esp32_zephyr-elf -h -c && deactivate
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
Create base Docker images for ESP-IDF and ZephyrOS/MCUboot development environments. These container images do not contain any secure boot or application specific content, and are meant to be used as generic devenv containers and base images for higher level devenv containers.

Publish these base images to GitHub Container Registry in CI. We use two jobs in the workflow for building the container images, to make it less likely to run out of GHA runner's disk space.