### PR TITLE
GHA: update actions/checkout to v4.1.1

### DIFF
--- a/.github/workflows/container-build-check.yml
+++ b/.github/workflows/container-build-check.yml
@@ -70,6 +70,13 @@ jobs:
       - name: "Test building container esp32s2zephyr"
         run: |
           set -euxo pipefail
+
+          # "Out of disk space" workaround
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
           cd ${{ github.workspace }}/esp32s2
           docker build -f Dockerfile.esp32s2_mcuboot_zephyr \
             --build-arg SBV2_PRIVATE_KEY="sbv2_private_dev.pem" \
@@ -110,6 +117,13 @@ jobs:
       - name: "Test building container esp32zephyr"
         run: |
           set -euxo pipefail
+
+          # "Out of disk space" workaround
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
           cd ${{ github.workspace }}/esp32
           docker build -f Dockerfile.esp32_mcuboot_zephyr \
             --build-arg SBV2_PRIVATE_KEY="sbv2_private_dev.pem" \

--- a/.github/workflows/container-build-check.yml
+++ b/.github/workflows/container-build-check.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: "Test building container esp32s3"
         run: |
           set -euxo pipefail
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: "Test building fuse blower container esp32s2fb"
         run: |
           set -euxo pipefail
@@ -66,7 +66,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: "Test building container esp32s2zephyr"
         run: |
           set -euxo pipefail
@@ -86,7 +86,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: "Test building fuse blower container esp32s2fb"
         run: |
           set -euxo pipefail
@@ -106,7 +106,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: "Test building container esp32zephyr"
         run: |
           set -euxo pipefail

--- a/.github/workflows/pub-ghcr.yml
+++ b/.github/workflows/pub-ghcr.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: "Build container"
         run: |
           set -euxo pipefail

--- a/.github/workflows/pub-ghcr.yml
+++ b/.github/workflows/pub-ghcr.yml
@@ -20,6 +20,15 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v4.1.1
+      - name: "Out-of-disk-space workaround"
+        run: |
+          set -euxo pipefail
+          # "Out of disk space" workaround
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+
       - name: "Build container"
         run: |
           set -euxo pipefail

--- a/.github/workflows/publish-devenv-base-images.yml
+++ b/.github/workflows/publish-devenv-base-images.yml
@@ -16,7 +16,7 @@ jobs:
       idf_target_image_name: 'devenv_idf_base'
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: "Build base containers"
         run: |
           set -euxo pipefail
@@ -41,7 +41,7 @@ jobs:
       zephyr_target_image_name: 'devenv_zephyr_base'
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: "Build base containers"
         run: |
           set -euxo pipefail


### PR DESCRIPTION
Move away from the deprecated node 12.