### PR TITLE
Update base container images to latest

### DIFF
--- a/esp32/Dockerfile.esp32_fuseblower
+++ b/esp32/Dockerfile.esp32_fuseblower
@@ -7,7 +7,7 @@
 #
 # Reference:
 # - https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/linux-macos-setup.html
-FROM ghcr.io/thistletech/devenv_idf_base:91717a88614327e2c1bd75452d9d0118a04a6400
+FROM ghcr.io/thistletech/devenv_idf_base:ac9abb297be64e86401562e04435fca316a38dff
 
 # sdkconfig file used to build IDF apps (non-MCUboot), for secure boot related
 # stuff

--- a/esp32/Dockerfile.esp32_mcuboot_zephyr
+++ b/esp32/Dockerfile.esp32_mcuboot_zephyr
@@ -9,7 +9,7 @@
 # Reference:
 # - Secure boot: https://docs.mcuboot.com/readme-espressif.html
 # - Zephyr dev: https://docs.zephyrproject.org/latest/develop/getting_started/index.html
-FROM ghcr.io/thistletech/devenv_zephyr_base:91717a88614327e2c1bd75452d9d0118a04a6400
+FROM ghcr.io/thistletech/devenv_zephyr_base:ac9abb297be64e86401562e04435fca316a38dff
 
 ARG TARGET="esp32"
 ARG ZEPHYR_BOARD_NAME="esp32"

--- a/esp32s2/Dockerfile.esp32s2_fuseblower
+++ b/esp32s2/Dockerfile.esp32s2_fuseblower
@@ -7,7 +7,7 @@
 #
 # Reference:
 # - https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/get-started/linux-macos-setup.html
-FROM ghcr.io/thistletech/devenv_idf_base:91717a88614327e2c1bd75452d9d0118a04a6400
+FROM ghcr.io/thistletech/devenv_idf_base:ac9abb297be64e86401562e04435fca316a38dff
 
 # sdkconfig file used to build IDF apps (non-MCUboot), for secure boot related
 # stuff

--- a/esp32s2/Dockerfile.esp32s2_mcuboot_zephyr
+++ b/esp32s2/Dockerfile.esp32s2_mcuboot_zephyr
@@ -9,7 +9,7 @@
 # Reference:
 # - Secure boot: https://docs.mcuboot.com/readme-espressif.html
 # - Zephyr dev: https://docs.zephyrproject.org/latest/develop/getting_started/index.html
-FROM ghcr.io/thistletech/devenv_zephyr_base:91717a88614327e2c1bd75452d9d0118a04a6400
+FROM ghcr.io/thistletech/devenv_zephyr_base:ac9abb297be64e86401562e04435fca316a38dff
 
 ARG TARGET="esp32s2"
 ARG ZEPHYR_BOARD_NAME="esp32s2_saola"

--- a/esp32s3/Dockerfile.esp32s3_fuseblower
+++ b/esp32s3/Dockerfile.esp32s3_fuseblower
@@ -7,7 +7,7 @@
 #
 # Reference:
 # - https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/get-started/linux-macos-setup.html
-FROM ghcr.io/thistletech/devenv_idf_base:91717a88614327e2c1bd75452d9d0118a04a6400
+FROM ghcr.io/thistletech/devenv_idf_base:ac9abb297be64e86401562e04435fca316a38dff
 
 # sdkconfig file used to build IDF apps (non-MCUboot), for secure boot related
 # stuff. File must be under directory configs/


### PR DESCRIPTION
Use the latest `devenv_zephyr_base` and `devenv_idf_base` prebuilt docker images to build final devenv images.