### PR TITLE
Fix broken symlinks for esp32s3 void_app

### DIFF
--- a/esp32s3/apps/void_app/sbv2_private.pem
+++ b/esp32s3/apps/void_app/sbv2_private.pem
@@ -1,0 +1,1 @@
+../sbv2_private_pem.app

--- a/esp32s3/apps/void_app/sdkconfig.defaults
+++ b/esp32s3/apps/void_app/sdkconfig.defaults
@@ -1,1 +1,1 @@
-../fusing/efuse_configs/sdkconfig.dev-sbv2_with_jtag
+../sdkconfig.apps

--- a/esp32s3/apps/void_app/secure_boot_signing_key_private-dev.pem
+++ b/esp32s3/apps/void_app/secure_boot_signing_key_private-dev.pem
@@ -1,1 +1,0 @@
-../keys/secure_boot_signing_key_private-dev.pem


### PR DESCRIPTION
Fix a bug that caused the void_app's bootloader and app images not correctly signed.

Improve documentation.